### PR TITLE
feat(arcbrush): 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/ar/arcbrush/default.nix
+++ b/pkgs/ar/arcbrush/default.nix
@@ -5,11 +5,11 @@
 
 let
   pname = "arcbrush";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchurl {
     url = "https://arcbrush.com/downloads/ArcBrush-${version}-x86_64.AppImage";
-    hash = "sha256-SChRCWJY3BFMF+Zqz8K5l5PhicU8prHJhZ5MRM0iYXY=";
+    hash = "sha256-WzBp4TOy0xsbuKjU4mv4LSfIFz+HGgZNkH7KTcb5wwc=";
   };
 in
 appimageTools.wrapType2 {


### PR DESCRIPTION
Updates `arcbrush` from `1.2.0` to `1.3.0`.

Generated by bumpkin.