### PR TITLE
feat(waterfox): 6.6.13 -> 6.6.14

### DIFF
--- a/pkgs/wa/waterfox-unwrapped/default.nix
+++ b/pkgs/wa/waterfox-unwrapped/default.nix
@@ -8,7 +8,7 @@
 
 (buildMozillaMach rec {
   pname = "waterfox";
-  version = "6.6.13";
+  version = "6.6.14";
 
   applicationName = "Waterfox";
   binaryName = "waterfox";
@@ -18,7 +18,7 @@
     owner = "BrowserWorks";
     repo = "Waterfox";
     tag = version;
-    hash = "sha256-fHbEF1C0nwRaEjTpKKDDO2FoyVaxQL0GaskHrCbBEcc=";
+    hash = "sha256-SjN/LotSmTEePS/eECUvJkiPiv5NfnSxME1EULHuhDY=";
     fetchSubmodules = true;
     preFetch = ''
       export GIT_CONFIG_COUNT=1


### PR DESCRIPTION
Update `waterfox` from `6.6.13` to `6.6.14`.

**Build:** skipped (in no-build list)

Generated by [bumpkin](https://github.com/74k1/bumpkin).