### PR TITLE
feat(lidarr): 3.1.3.4968 -> 3.1.3.4968

### DIFF
--- a/pkgs/li/lidarr/default.nix
+++ b/pkgs/li/lidarr/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/Lidarr/Lidarr/releases/download/v${version}/Lidarr.develop.${version}.linux-core-x64.tar.gz";
-    hash = "sha256-jhTloumon3y3ooFDSnSE0bljL8UvLMBrsDpRAnFN3dE=";
+    hash = "sha256-TFpKRjXDiPwGwp6DddrbL4Jy6cNk0g1Yoo83Pz0kWGI=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Update `lidarr` from `3.1.3.4968` to `3.1.3.4968`.

**Built on platform:**

- [ ] `x86_64-linux` failed ⚠️

Generated by [bumpkin](https://github.com/74k1/bumpkin).

<details>
<summary>Build log (last 20 lines)</summary>

```
these 2 derivations will be built:
  /nix/store/6rarxm5sshck3i984q93vcgphi70jzxw-Lidarr.develop.3.1.3.4968.linux-core-x64.tar.gz.drv
  /nix/store/zwpn9dhaw10h0kyv224z4bznlz7nbgzi-lidarr-3.1.3.4968.drv
building '/nix/store/6rarxm5sshck3i984q93vcgphi70jzxw-Lidarr.develop.3.1.3.4968.linux-core-x64.tar.gz.drv'...
error: hash mismatch in fixed-output derivation '/nix/store/6rarxm5sshck3i984q93vcgphi70jzxw-Lidarr.develop.3.1.3.4968.linux-core-x64.tar.gz.drv':
           likely URL: (unknown)
            specified: sha256-TFpKRjXDiPwGwp6DddrbL4Jy6cNk0g1Yoo83Pz0kWGI=
                  got: sha256-jhTloumon3y3ooFDSnSE0bljL8UvLMBrsDpRAnFN3dE=
        expected path: /nix/store/1wvxq7gpxlqjslz1qhkf4glxf9myc73k-Lidarr.develop.3.1.3.4968.linux-core-x64.tar.gz
             got path: /nix/store/xnmg79ssckmclnb6cvpips3amhgkk25h-Lidarr.develop.3.1.3.4968.linux-core-x64.tar.gz
error: 1 dependencies of derivation '/nix/store/zwpn9dhaw10h0kyv224z4bznlz7nbgzi-lidarr-3.1.3.4968.drv' failed to build
```
</details>
