### PR TITLE
feat(godap): 2.10.4 -> 2.11.0

### DIFF
--- a/pkgs/go/godap/default.nix
+++ b/pkgs/go/godap/default.nix
@@ -6,14 +6,14 @@
 
 buildGoModule rec {
   pname = "godap";
-  version = "2.10.4";
+  version = "2.11.0";
   src = fetchFromGitHub {
     owner = "Macmod";
     repo = "godap";
     rev = "v${version}";
-    hash = "sha256-mvzVOuFZABGE7DH3AkhOXvsvSZzgpW0aJUdXW6N6hf0=";
+    hash = "sha256-um9IsORwD4rPcqklEsRYI+J86R2vf7SE4RnTpaM6PnA=";
   };
-  vendorHash = "sha256-NiNhKbf5bU1SQXFTZCp8/yNPc89ss8go6M2867ziqq4=";
+  vendorHash = "sha256-D5Eq2JFIEmxO/FBGON+nKtGktWPOzXfv8l5akRTpz7Q=";
 
   meta = with lib; {
     description = "A lightweight LDAP directory server";


### PR DESCRIPTION
Update `godap` from `2.10.4` to `2.11.0`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).