### PR TITLE
feat(mtkclient): 5794aba -> 2c9f4d7

### DIFF
--- a/pkgs/mt/mtkclient/default.nix
+++ b/pkgs/mt/mtkclient/default.nix
@@ -7,19 +7,20 @@
 python3.pkgs.buildPythonPackage rec {
   pyproject = true;
   pname = "mtkclient";
-  version = "5794aba";
+  version = "2c9f4d7";
 
   buildInputs = with pkgs; [
     pkgs.keystone
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
-    hatchling
     capstone
     colorama
     flake8
     fusepy
+    hatchling
     keystone-engine
+    mfusepy
     pycryptodome
     pycryptodomex
     pyserial
@@ -33,8 +34,8 @@ python3.pkgs.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "bkerler";
     repo = "mtkclient";
-    rev = "5794aba14a8753cd8186cd0ec2ce5ae73e3ea2f2";
-    hash = "sha256-M16posU6FGobiFbXvFBE5C0otACD2SPRLubwA+STKxs=";
+    rev = "2c9f4d78601e2b223cacfed773a5c4cbb1808189";
+    hash = "sha256-isQKurmKQavxGH/LnD2pXn+zbXUK+5KwMXwkT9TprPM=";
   };
 
   postFixup = ''


### PR DESCRIPTION
Update `mtkclient` from `5794aba` to `2c9f4d7`.

**Built on platform:**

- [ ] `x86_64-linux` failed ⚠️

Generated by [bumpkin](https://github.com/74k1/bumpkin).

<details>
<summary>Build log (last 20 lines)</summary>

```
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/uv.lock"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       > * Building wheel...
       > Successfully built mtkclient-2.1.4-py3-none-any.whl
       > Finished creating a wheel...
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for mtkclient-2.1.4-py3-none-any.whl
       >   - mfusepy not installed
       For full logs, run:
         nix log /nix/store/cyclrwga814kh3l2fyam2lflas78kkjs-python3.13-mtkclient-2c9f4d7.drv
```
</details>
