### PR TITLE
feat(waterfox-unwrapped): 6.6.14 -> 6.6.15

### DIFF
--- a/pkgs/wa/waterfox-unwrapped/default.nix
+++ b/pkgs/wa/waterfox-unwrapped/default.nix
@@ -8,7 +8,7 @@
 
 (buildMozillaMach rec {
   pname = "waterfox";
-  version = "6.6.14";
+  version = "6.6.15";
 
   applicationName = "Waterfox";
   binaryName = "waterfox";
@@ -18,7 +18,7 @@
     owner = "BrowserWorks";
     repo = "Waterfox";
     tag = version;
-    hash = "sha256-SjN/LotSmTEePS/eECUvJkiPiv5NfnSxME1EULHuhDY=";
+    hash = "sha256-pwEG42CTXjT//xIoESkhB1OD3G1L3Dp//mXjG9a9k5I=";
     fetchSubmodules = true;
     preFetch = ''
       export GIT_CONFIG_COUNT=1


### PR DESCRIPTION
Update `waterfox-unwrapped` from `6.6.14` to `6.6.15`.

**Built on platform:**

- [ ] `x86_64-linux` skipped ⏩ (in no-build list)

Generated by [bumpkin](https://github.com/74k1/bumpkin).