### PR TITLE
feat(parallels-ras-client): 21.1.26543 -> 21.2.27178

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Packages can be used using `inputs.tixpkgs.packages.${pkgs.stdenv.hostPlatform.s
 | `mtkclient` | `2c9f4d7` |
 | `multi-scrobbler` | `0.14.1` |
 | `outerbase-studio-desktop` | `0.1.29` |
-| `parallels-ras-client` | `21.1.26543` |
+| `parallels-ras-client` | `21.2.27178` |
 | `rybbit` | `2.6.1` |
 | `waterfox` | `6.6.15` |
 | `waterfox-unwrapped` | `6.6.15` |

--- a/pkgs/pa/parallels-ras-client/default.nix
+++ b/pkgs/pa/parallels-ras-client/default.nix
@@ -24,11 +24,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "parallels-ras-client";
-  version = "21.1.26543";
+  version = "21.2.27178";
 
   src = fetchurl {
-    url = "https://download.parallels.com/ras/v21/21.1.0.26543/RASClient-${finalAttrs.version}_x86_64.tar.bz2";
-    hash = "sha256-JEg4CeYTJhhD/r+r77rW4agzM5NRJkcVYGzovGuEsDA=";
+    url =
+      let
+        v = lib.versions.splitVersion finalAttrs.version;
+        major = builtins.elemAt v 0;
+        minor = builtins.elemAt v 1;
+        build = builtins.elemAt v 2;
+      in
+      "https://download.parallels.com/ras/v${major}/${major}.${minor}.0.${build}/RASClient-${finalAttrs.version}_x86_64.tar.bz2";
+    hash = "sha256-Qc06RNgZPsDdgeKsOjijM1Ytgyh9enh8BiilrVQKHos=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update `parallels-ras-client` from `21.1.26543` to `21.2.27178`.

**Built on platform:**

- [ ] `x86_64-linux` failed ⚠️

Generated by [bumpkin](https://github.com/74k1/bumpkin).

<details>
<summary>Build log (last 20 lines)</summary>

```
       > structuredAttrs is enabled
       >
       > trying https://download.parallels.com/ras/v21/21.1.0.26543/RASClient-21.2.27178_x86_64.tar.bz2
       >   % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
       >                                  Dload  Upload  Total   Spent   Left   Speed
       >   0      0   0      0   0      0      0      0                              0
       > curl: (22) The requested URL returned error: 404
       > Warning: Problem (retrying all errors). Retrying in 1 second. 3 retries left.
       >   0      0   0      0   0      0      0      0                              0
       > curl: (22) The requested URL returned error: 404
       > Warning: Problem (retrying all errors). Retrying in 2 seconds. 2 retries left.
       >   0      0   0      0   0      0      0      0                              0
       > curl: (22) The requested URL returned error: 404
       > Warning: Problem (retrying all errors). Retrying in 4 seconds. 1 retry left.
       >   0      0   0      0   0      0      0      0                              0
       > curl: (22) The requested URL returned error: 404
       > error: cannot download RASClient-21.2.27178_x86_64.tar.bz2 from any mirror
       For full logs, run:
             nix log /nix/store/jmhvznys5ipvc5j3d3zlsf8863sw6197-RASClient-21.2.27178_x86_64.tar.bz2.drv
error: 1 dependencies of derivation '/nix/store/k4cg9vr4xyh78ayswz4r7bximapvbn3h-parallels-ras-client-21.2.27178.drv' failed to build
```
</details>
