### PR TITLE
feat(godap): 2.11.0 -> 2.11.1

### DIFF
--- a/pkgs/go/godap/default.nix
+++ b/pkgs/go/godap/default.nix
@@ -6,12 +6,12 @@
 
 buildGoModule rec {
   pname = "godap";
-  version = "2.11.0";
+  version = "2.11.1";
   src = fetchFromGitHub {
     owner = "Macmod";
     repo = "godap";
     rev = "v${version}";
-    hash = "sha256-um9IsORwD4rPcqklEsRYI+J86R2vf7SE4RnTpaM6PnA=";
+    hash = "sha256-004j01OcFz8MgWBp3r+ejBJuR6hjy9U9S0b6A6GRS5U=";
   };
   vendorHash = "sha256-D5Eq2JFIEmxO/FBGON+nKtGktWPOzXfv8l5akRTpz7Q=";
 


### PR DESCRIPTION
Update `godap` from `2.11.0` to `2.11.1`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).