### PR TITLE
feat(arcbrush): 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/ar/arcbrush/default.nix
+++ b/pkgs/ar/arcbrush/default.nix
@@ -6,11 +6,11 @@
 
 let
   pname = "arcbrush";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchurl {
     url = "https://arcbrush.com/downloads/ArcBrush-${version}-x86_64.AppImage";
-    hash = "sha256-SS/qeyqcOza5Tu39sYA62eSWk/7bALtSl+24U/Oktyk=";
+    hash = "sha256-PmJkcqeTGUC2GSx3BVBWhSFKtwtyrg4nJ+J4XGuCM/4=";
   };
 in
 appimageTools.wrapType2 {


### PR DESCRIPTION
Update `arcbrush` from `1.4.0` to `1.5.0`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).