### PR TITLE
feat(lidarr): 3.1.3.4968 -> 3.1.3.4975

### DIFF
--- a/pkgs/li/lidarr/default.nix
+++ b/pkgs/li/lidarr/default.nix
@@ -14,11 +14,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "lidarr";
-  version = "3.1.3.4968";
+  version = "3.1.3.4975";
 
   src = fetchurl {
     url = "https://github.com/Lidarr/Lidarr/releases/download/v${version}/Lidarr.develop.${version}.linux-core-x64.tar.gz";
-    hash = "sha256-jhTloumon3y3ooFDSnSE0bljL8UvLMBrsDpRAnFN3dE=";
+    hash = "sha256-8eyWgkErVQDoLkL/3gtBlfxmKltLy0cpfG9AZZAp5c0=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Update `lidarr` from `3.1.3.4968` to `3.1.3.4975`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).