### PR TITLE
feat(fogpanther): 0.8.0 -> 0.8.0

### DIFF
--- a/pkgs/fo/fogpanther/default.nix
+++ b/pkgs/fo/fogpanther/default.nix
@@ -33,6 +33,7 @@
   libdeflate,
   glib-networking,
   hicolor-icon-theme,
+  libarchive,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -46,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
       cacert
     ];
 
-    outputHash = "sha256-WXjRDBxL4O0esgW3QB5x9Hb/d95qo/QcH/Lrb9yNtjo=";
+    outputHash = "sha256-B3CVGhol9bOcdvWyH/wr/pjKiTnmMKnBZuoKIv/q3h4=";
     outputHashAlgo = "sha256";
     outputHashMode = "flat";
 
@@ -92,6 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     libdeflate
     glib-networking
     hicolor-icon-theme
+    libarchive
     stdenv.cc.cc.lib
   ];
 


### PR DESCRIPTION
Update `fogpanther` from `0.8.0` to `0.8.0`.

**Built on platform:**

- [ ] `x86_64-linux` failed ⚠️

Generated by [bumpkin](https://github.com/74k1/bumpkin).

<details>
<summary>Build log (last 20 lines)</summary>

```
       >     libgdk_pixbuf-2.0.so.0 -> found: /nix/store/rgr3i966i5wnblv62fvkid3v3lxy1ivb-gdk-pixbuf-2.44.6/lib
       >     libgobject-2.0.so.0 -> found: /nix/store/7dl2py4dnp4ffj92r1lq0i54ik1v8kzn-glib-2.88.1/lib
       >     libglib-2.0.so.0 -> found: /nix/store/7dl2py4dnp4ffj92r1lq0i54ik1v8kzn-glib-2.88.1/lib
       >     libgio-2.0.so.0 -> found: /nix/store/7dl2py4dnp4ffj92r1lq0i54ik1v8kzn-glib-2.88.1/lib
       >     libarchive.so.13 -> not found!
       >     libsodium.so.26 -> found: /nix/store/855xbbih27lz4d6p0s4qrzwgscvpjcwp-fogpanther-0.8.0/opt/fogpanther/lib
       > setting RPATH to: /nix/store/rgr3i966i5wnblv62fvkid3v3lxy1ivb-gdk-pixbuf-2.44.6/lib:/nix/store/7dl2py4dnp4ffj92r1lq0i54ik1v8kzn-glib-2.88.1/lib:/nix/store/855xbbih27lz4d6p0s4qrzwgscvpjcwp-fogpanther-0.8.0/opt/fogpanther/lib:$out/opt/fogpanther/lib
       > searching for dependencies of /nix/store/855xbbih27lz4d6p0s4qrzwgscvpjcwp-fogpanther-0.8.0/opt/fogpanther/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-hdr.so
       >     libgdk_pixbuf-2.0.so.0 -> found: /nix/store/rgr3i966i5wnblv62fvkid3v3lxy1ivb-gdk-pixbuf-2.44.6/lib
       >     libgobject-2.0.so.0 -> found: /nix/store/7dl2py4dnp4ffj92r1lq0i54ik1v8kzn-glib-2.88.1/lib
       >     libglib-2.0.so.0 -> found: /nix/store/7dl2py4dnp4ffj92r1lq0i54ik1v8kzn-glib-2.88.1/lib
       > setting RPATH to: /nix/store/rgr3i966i5wnblv62fvkid3v3lxy1ivb-gdk-pixbuf-2.44.6/lib:/nix/store/7dl2py4dnp4ffj92r1lq0i54ik1v8kzn-glib-2.88.1/lib:$out/opt/fogpanther/lib
       > auto-patchelf: 3 dependencies could not be satisfied
       > error: auto-patchelf could not satisfy dependency libarchive.so.13 wanted by /nix/store/855xbbih27lz4d6p0s4qrzwgscvpjcwp-fogpanther-0.8.0/opt/fogpanther/bin/fogpanther
       > error: auto-patchelf could not satisfy dependency libarchive.so.13 wanted by /nix/store/855xbbih27lz4d6p0s4qrzwgscvpjcwp-fogpanther-0.8.0/opt/fogpanther/bin/fogpanther-thumbnailer
       > error: auto-patchelf could not satisfy dependency libarchive.so.13 wanted by /nix/store/855xbbih27lz4d6p0s4qrzwgscvpjcwp-fogpanther-0.8.0/opt/fogpanther/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-fog.so
       > auto-patchelf failed to find all the required dependencies.
       > Add the missing dependencies to --libs or use `--ignore-missing="foo.so.1 bar.so etc.so"`.
       For full logs, run:
         nix log /nix/store/wfm56j5nck6ik4bnfxnaw826gry10kw9-fogpanther-0.8.0.drv
```
</details>
