### PR TITLE
feat(multi-scrobbler): 0.14.1 -> 0.14.2

### DIFF
--- a/pkgs/mu/multi-scrobbler/default.nix
+++ b/pkgs/mu/multi-scrobbler/default.nix
@@ -8,18 +8,20 @@
 
 buildNpmPackage rec {
   pname = "multi-scrobbler";
-  version = "0.14.1";
+  version = "0.14.2";
 
   src = fetchFromGitHub {
     owner = "FoxxMD";
     repo = "multi-scrobbler";
     rev = version;
-    hash = "sha256-WrNheETW6snvtitL2IOcOQWBZgfLOIPO/x5Y8Q6lmTc=";
+    hash = "sha256-FHpHVQ3M/n8/LcMvl2LGakTjS6u2IebhGZRrO4GAZf8=";
   };
 
-  npmDepsHash = "sha256-K6zKmkjoBcshZ9mWeM1BiBFtM8/ekf9A1S1xwJ/p7PA=";
+  npmDepsHash = "sha256-b8BYqJVOSOInW1H2DpxBN9ETcVHA8/f/yHJ8b72zvsk=";
 
-  npmBuildScript = "build:backend";
+  npmBuildScript = "schema:app";
+
+  npmRebuildFlags = [ "--ignore-scripts" ];
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
Update `multi-scrobbler` from `0.14.1` to `0.14.2`.

**Built on platform:**

- [ ] `x86_64-linux` failed ⚠️

Generated by [bumpkin](https://github.com/74k1/bumpkin).

<details>
<summary>Build log (last 20 lines)</summary>

```
       > node_modules/storybook/dist/bin/dispatcher.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/zvj0hl7rhh0ccr5vkcg3ijs3xm3sgyac-nodejs-24.16.0/bin/node"
       > node_modules/open/xdg-open: interpreter directive changed from "#!/bin/sh" to "/nix/store/zh1ijdhb6gng1509b1zrilb6xlzx60j6-bash-5.3p9/bin/sh"
       > npm warn Unknown env config "nodedir". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm warn Unknown env config "platform". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm warn Unknown env config "arch". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm error code 1
       > npm error path /build/source/node_modules/storybook-addon-remix-react-router
       > npm error command failed
       > npm error command sh -c npx only-allow pnpm
       > npm error npm warn Unknown env config "nodedir". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm error npm warn Unknown env config "platform". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm error npm warn Unknown env config "arch". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm error npm error code ENOTCACHED
       > npm error npm error request to https://registry.npmjs.org/only-allow failed: cache mode is 'only-if-cached' but no cached response is available.
       > npm error npm error Log files were not written due to an error writing to the directory: /nix/store/ry4xv6gbzcds13j836y8is0lbsy58ssc-multi-scrobbler-0.14.2-npm-deps/_logs
       > npm error npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
       > npm error Log files were not written due to an error writing to the directory: /nix/store/ry4xv6gbzcds13j836y8is0lbsy58ssc-multi-scrobbler-0.14.2-npm-deps/_logs
       > npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
       For full logs, run:
               nix log /nix/store/ywxxrh5ay35y1mzaw72ip64jdx1ip7ga-multi-scrobbler-0.14.2.drv
```
</details>
