### PR TITLE
feat(trek): 3.4.1 -> 3.4.1

### DIFF
--- a/pkgs/tr/trek/default.nix
+++ b/pkgs/tr/trek/default.nix
@@ -11,7 +11,7 @@ buildNpmPackage (finalAttrs: {
   version = "3.4.1";
 
   src = fetchFromGitHub {
-    owner = "mauriceboe";
+    owner = "liketrek";
     repo = "TREK";
     tag = "v${finalAttrs.version}";
     hash = "sha256-r7Y6vxksX+V4bKCz4MF7K8Ar5UgKIzHoJmjukgR+9Cw=";


### PR DESCRIPTION
Update `trek` from `3.4.1` to `3.4.1`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).