### PR TITLE
feat(multi-scrobbler): 0.14.2 -> 0.15.0

### DIFF
--- a/modules/nixos/services/multi-scrobbler/README.md
+++ b/modules/nixos/services/multi-scrobbler/README.md
@@ -105,7 +105,9 @@ CUSTOM_SPOTIFY_CLIENT_SECRET=...
 
 ## Notes
 
-`configFiles` writes typed JSON config files like `spotify.json` and `lastfm.json`.
+`stateDir` is used for both upstream `CONFIG_DIR` and `DATA_DIR`, so configuration, databases, logs, and credentials remain in one persistent location.
+
+`configFiles` writes typed JSON config files like `spotify.json`, `applemusic.json`, and `lastfm.json`.
 
 - The attribute name becomes the upstream file type.
 - A single attrset is wrapped into the upstream array format automatically.

--- a/modules/nixos/services/multi-scrobbler/default.nix
+++ b/modules/nixos/services/multi-scrobbler/default.nix
@@ -78,6 +78,7 @@ let
     "rocksky"
     "sonos"
     "ymbridge"
+    "applemusic"
   ];
 
   clientTypes = [
@@ -94,6 +95,7 @@ let
   configFileTypes = lib.unique (sourceTypes ++ clientTypes);
 
   upstreamAutoConfigEnvPrefixes = [
+    "APPLEMUSIC_"
     "AZURACAST_"
     "CHROMECAST_"
     "DEEZER_"
@@ -131,6 +133,7 @@ let
   reservedEnvironmentKeys = [
     "BASE_URL"
     "CONFIG_DIR"
+    "DATA_DIR"
     "PORT"
   ];
 
@@ -173,6 +176,7 @@ let
     cfg.environment
     // {
       CONFIG_DIR = cfg.stateDir;
+      DATA_DIR = cfg.stateDir;
       PORT = cfg.port;
     }
     // lib.optionalAttrs (cfg.baseUrl != null) {
@@ -275,8 +279,8 @@ in
         neutral names like `CUSTOM_SPOTIFY_CLIENT_ID` and reference them from JSON
         as `[[CUSTOM_SPOTIFY_CLIENT_ID]]`.
 
-        `PORT`, `BASE_URL`, and `CONFIG_DIR` are managed by dedicated module
-        options and must not be set here.
+        `PORT`, `BASE_URL`, `CONFIG_DIR`, and `DATA_DIR` are managed by
+        dedicated module options and must not be set here.
       '';
     };
 
@@ -360,7 +364,9 @@ in
       default = defaultStateDir;
       example = "/opt/multi-scrobbler";
       description = ''
-        Directory used as multi-scrobbler's `CONFIG_DIR` and working directory.
+        Directory used as multi-scrobbler's `CONFIG_DIR`, `DATA_DIR`, and
+        working directory. Keeping both upstream directories together preserves
+        databases, logs, and credentials across the 0.15.0 upgrade.
 
         With `DynamicUser = true`, the service's mutable state is still managed by
         systemd. When this path differs from the default, the module exposes it as

--- a/pkgs/mu/multi-scrobbler/default.nix
+++ b/pkgs/mu/multi-scrobbler/default.nix
@@ -8,18 +8,18 @@
 
 buildNpmPackage rec {
   pname = "multi-scrobbler";
-  version = "0.14.2";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "FoxxMD";
     repo = "multi-scrobbler";
     rev = version;
-    hash = "sha256-FHpHVQ3M/n8/LcMvl2LGakTjS6u2IebhGZRrO4GAZf8=";
+    hash = "sha256-vhda31xPLxGmnaU/3AnsrcafPvSE1IIbuRmj6xlttjc=";
   };
 
-  npmDepsHash = "sha256-b8BYqJVOSOInW1H2DpxBN9ETcVHA8/f/yHJ8b72zvsk=";
+  npmDepsHash = "sha256-M0F0YnQ35YEioMzt4lJiUM/Iqfrb7/zwUG/vFGl+JSY=";
 
-  npmBuildScript = "schema:app";
+  npmBuildScript = "build:frontend";
 
   npmRebuildFlags = [ "--ignore-scripts" ];
 
@@ -87,10 +87,6 @@ buildNpmPackage rec {
     MIGEOF
   '';
 
-  postBuild = ''
-    npm run build:frontend
-  '';
-
   installPhase = ''
     runHook preInstall
 
@@ -103,12 +99,10 @@ buildNpmPackage rec {
     makeWrapper ${lib.getExe nodejs_24} $out/bin/${pname} \
       --chdir $out/share/${pname} \
       --set NODE_ENV production \
-      --add-flags ./node_modules/.bin/tsx \
       --add-flags ./src/backend/index.ts
 
     makeWrapper ${lib.getExe nodejs_24} $out/bin/${pname}-service \
       --set NODE_ENV production \
-      --add-flags $out/share/${pname}/node_modules/.bin/tsx \
       --add-flags $out/share/${pname}/src/backend/index.ts
 
     runHook postInstall


### PR DESCRIPTION
Update `multi-scrobbler` from `0.14.2` to `0.15.0`.

**Built on platform:**

- [ ] `x86_64-linux` failed ⚠️

Generated by [bumpkin](https://github.com/74k1/bumpkin).

<details>
<summary>Build log (last 20 lines)</summary>

```
       > npm warn Unknown env config "nodedir". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm warn Unknown env config "platform". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm warn Unknown env config "arch". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
       > npm error Missing script: "schema:app"
       > npm error
       > npm error To see a list of scripts, run:
       > npm error   npm run
       > npm error Log files were not written due to an error writing to the directory: /nix/store/0mxd0qz5pnja6yzn59xig3scqn04hiaz-multi-scrobbler-0.15.0-npm-deps/_logs
       > npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
       >
       > ERROR: `npm run schema:app [...]` failed
       >
       > Here are a few things you can try, depending on the error:
       > 1. Make sure your build script (schema:app) exists
       >   If there is none, set `dontNpmBuild = true`.
       > 2. If the error being thrown is something similar to "error:0308010C:digital envelope routines::unsupported", add `NODE_OPTIONS = "--openssl-legacy-provider"` to your derivation
       >   See https://github.com/webpack/webpack/issues/14532 for more information.
       >
       For full logs, run:
         nix log /nix/store/6fqivkwcffakzhl1qhr22kx9099z3q4m-multi-scrobbler-0.15.0.drv
```
</details>
