### PR TITLE
feat(parallels-ras-client): 21.2.27178 -> 21.2.27300

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Packages can be used using `inputs.tixpkgs.packages.${pkgs.stdenv.hostPlatform.s
 | `mtkclient` | `382fb30` |
 | `multi-scrobbler` | `0.14.2` |
 | `outerbase-studio-desktop` | `0.1.29` |
-| `parallels-ras-client` | `21.2.27178` |
+| `parallels-ras-client` | `21.2.27300` |
 | `rybbit` | `2.8.0` |
 | `trek` | `3.4.1` |
 | `yopass` | `14.0.0` |

--- a/pkgs/pa/parallels-ras-client/default.nix
+++ b/pkgs/pa/parallels-ras-client/default.nix
@@ -24,18 +24,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "parallels-ras-client";
-  version = "21.2.27178";
+  version = "21.2.27300";
 
   src = fetchurl {
-    url =
-      let
-        v = lib.versions.splitVersion finalAttrs.version;
-        major = builtins.elemAt v 0;
-        minor = builtins.elemAt v 1;
-        build = builtins.elemAt v 2;
-      in
-      "https://download.parallels.com/ras/v${major}/${major}.${minor}.0.${build}/RASClient-${finalAttrs.version}_x86_64.tar.bz2";
-    hash = "sha256-Qc06RNgZPsDdgeKsOjijM1Ytgyh9enh8BiilrVQKHos=";
+    # The directory version is independent from the archive version.
+    url = "https://download.parallels.com/ras/v21/21.2.1.27300/RASClient-21.2.27300_x86_64.tar.bz2";
+    hash = "sha256-ZTHWpaw8/yAaS8JQRf06WxAU44GISSxiHi2zJJZlp7s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/pa/parallels-ras-client/update.sh
+++ b/pkgs/pa/parallels-ras-client/update.sh
@@ -8,6 +8,7 @@ readme_file="$root/README.md"
 base="https://download.parallels.com/website_links"
 
 old_version="$(perl -ne 'print $1 if /^\s*version = "([^"]+)";/' "$package_file")"
+old_url="$(perl -ne 'print $1 if /^\s*url = "([^"]+)";/' "$package_file")"
 old_hash="$(perl -ne 'print $1 if /^\s*hash = "([^"]+)";/' "$package_file")"
 
 index="$(curl -fsSL "$base/ras/index.json")"
@@ -18,7 +19,7 @@ builds="$(curl -fsSL "$base/$builds_path")"
 new_url="$(jq -r '.. | objects | select(.subcategory? == "Linux" and .name? == "x64") | .files["Linux Client - tar.bz2 64-bit"] // empty' <<< "$builds" | head -n1)"
 new_version="$(perl -ne 'print $1 if /RASClient-([0-9.]+)_x86_64[.]tar[.]bz2/' <<< "$new_url")"
 
-if [[ -z "$old_version" || -z "$old_hash" || -z "$new_version" || -z "$new_url" ]]; then
+if [[ -z "$old_version" || -z "$old_url" || -z "$old_hash" || -z "$new_version" || -z "$new_url" ]]; then
   echo "failed to read current or latest Parallels RAS Client metadata" >&2
   exit 1
 fi
@@ -30,16 +31,18 @@ archive="$tmpdir/ras-client.tar.bz2"
 curl -fsSL -o "$archive" "$new_url"
 new_hash="$(nix --extra-experimental-features nix-command hash file --type sha256 --sri "$archive")"
 
-if [[ "$old_version" == "$new_version" && "$old_hash" == "$new_hash" ]]; then
+if [[ "$old_version" == "$new_version" && "$old_url" == "$new_url" && "$old_hash" == "$new_hash" ]]; then
   echo "parallels-ras-client is already up to date ($new_version)." >&2
   printf '[]\n'
   exit 0
 fi
 
 OLD_VERSION="$old_version" NEW_VERSION="$new_version" \
+OLD_URL="$old_url" NEW_URL="$new_url" \
 OLD_HASH="$old_hash" NEW_HASH="$new_hash" \
 perl -0pi -e '
   s/version = "\Q$ENV{OLD_VERSION}\E";/version = "$ENV{NEW_VERSION}";/ or die "failed to replace version\n";
+  s/url = "\Q$ENV{OLD_URL}\E";/url = "$ENV{NEW_URL}";/ or die "failed to replace URL\n";
   s/hash = "\Q$ENV{OLD_HASH}\E";/hash = "$ENV{NEW_HASH}";/ or die "failed to replace hash\n";
 ' "$package_file"
 


### PR DESCRIPTION
Update `parallels-ras-client` from `21.2.27178` to `21.2.27300`.

**Built on platform:**

- [ ] `x86_64-linux` failed ⚠️

Generated by [bumpkin](https://github.com/74k1/bumpkin).

<details>
<summary>Build log (last 20 lines)</summary>

```
       > structuredAttrs is enabled
       >
       > trying https://download.parallels.com/ras/v21/21.2.0.27300/RASClient-21.2.27300_x86_64.tar.bz2
       >   % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
       >                                  Dload  Upload  Total   Spent   Left   Speed
       >   0      0   0      0   0      0      0      0                              0
       > curl: (22) The requested URL returned error: 404
       > Warning: Problem (retrying all errors). Retrying in 1 second. 3 retries left.
       >   0      0   0      0   0      0      0      0                              0
       > curl: (22) The requested URL returned error: 404
       > Warning: Problem (retrying all errors). Retrying in 2 seconds. 2 retries left.
       >   0      0   0      0   0      0      0      0                              0
       > curl: (22) The requested URL returned error: 404
       > Warning: Problem (retrying all errors). Retrying in 4 seconds. 1 retry left.
       >   0      0   0      0   0      0      0      0                              0
       > curl: (22) The requested URL returned error: 404
       > error: cannot download RASClient-21.2.27300_x86_64.tar.bz2 from any mirror
       For full logs, run:
             nix log /nix/store/phih1fvvagb1mqrsm33m5xya92gki25d-RASClient-21.2.27300_x86_64.tar.bz2.drv
error: 1 dependencies of derivation '/nix/store/6qj5b50knf41vzav7fidn176kl5mz7fp-parallels-ras-client-21.2.27300.drv' failed to build
```
</details>
