### PR TITLE
feat(multi-scrobbler): 0.16.2 -> 0.16.3

### DIFF
--- a/pkgs/mu/multi-scrobbler/default.nix
+++ b/pkgs/mu/multi-scrobbler/default.nix
@@ -8,16 +8,16 @@
 
 buildNpmPackage rec {
   pname = "multi-scrobbler";
-  version = "0.16.2";
+  version = "0.16.3";
 
   src = fetchFromGitHub {
     owner = "FoxxMD";
     repo = "multi-scrobbler";
     rev = version;
-    hash = "sha256-R+CwL+Kp3C5wg1LFt0XlksMtRFt+7YItR3t4QPpND6w=";
+    hash = "sha256-4nbRgkvNDNMLZjepvjtKK9R8VZAuVoQAG1e1yyfxFEc=";
   };
 
-  npmDepsHash = "sha256-mNKSFgNNOrXd2qcxruOksWM0Q8rQWLMpzcJgieN9c/Y=";
+  npmDepsHash = "sha256-fUaG2A2S6j8jzBT+aeq0/DUz+aHHljvHyYFvxd9vxF8=";
 
   npmBuildScript = "build:frontend";
 


### PR DESCRIPTION
Update `multi-scrobbler` from `0.16.2` to `0.16.3`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).