### PR TITLE
feat(godap): 2.11.1 -> 2.12.0

### DIFF
--- a/pkgs/go/godap/default.nix
+++ b/pkgs/go/godap/default.nix
@@ -6,14 +6,14 @@
 
 buildGoModule rec {
   pname = "godap";
-  version = "2.11.1";
+  version = "2.12.0";
   src = fetchFromGitHub {
     owner = "Macmod";
     repo = "godap";
     rev = "v${version}";
-    hash = "sha256-004j01OcFz8MgWBp3r+ejBJuR6hjy9U9S0b6A6GRS5U=";
+    hash = "sha256-0fJjGepfcYQ6MJquB9k2iT5d8cu/fqWD/RiR5RVsM50=";
   };
-  vendorHash = "sha256-D5Eq2JFIEmxO/FBGON+nKtGktWPOzXfv8l5akRTpz7Q=";
+  vendorHash = "sha256-wqBpsZdfU9xOGKbspWYq8A6xmCrIQrKFhx4s7M6K6/M=";
 
   meta = with lib; {
     description = "A lightweight LDAP directory server";


### PR DESCRIPTION
Update `godap` from `2.11.1` to `2.12.0`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).