### PR TITLE
feat(godap): 2.12.0 -> 2.12.2

### DIFF
--- a/pkgs/go/godap/default.nix
+++ b/pkgs/go/godap/default.nix
@@ -6,12 +6,12 @@
 
 buildGoModule rec {
   pname = "godap";
-  version = "2.12.0";
+  version = "2.12.2";
   src = fetchFromGitHub {
     owner = "Macmod";
     repo = "godap";
     rev = "v${version}";
-    hash = "sha256-0fJjGepfcYQ6MJquB9k2iT5d8cu/fqWD/RiR5RVsM50=";
+    hash = "sha256-8Xlf9VL1rJ7PMk8dRia0bmYkx1gCstnp/Sv9FO1BxSw=";
   };
   vendorHash = "sha256-wqBpsZdfU9xOGKbspWYq8A6xmCrIQrKFhx4s7M6K6/M=";
 


### PR DESCRIPTION
Update `godap` from `2.12.0` to `2.12.2`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).