### PR TITLE
feat(lidarr): 3.1.3.4987 -> 3.1.4.5029

### DIFF
--- a/pkgs/li/lidarr/default.nix
+++ b/pkgs/li/lidarr/default.nix
@@ -14,11 +14,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "lidarr";
-  version = "3.1.3.4987";
+  version = "3.1.4.5029";
 
   src = fetchurl {
     url = "https://github.com/Lidarr/Lidarr/releases/download/v${version}/Lidarr.develop.${version}.linux-core-x64.tar.gz";
-    hash = "sha256-5ScoNmV91YCQIXW3Cwi6Y/onpk1YXE4EbandXFPf5BM=";
+    hash = "sha256-OeARu0PtYS4+AJuSgINuR7xT9u4UORkqnok4T8OCFrE=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Update `lidarr` from `3.1.3.4987` to `3.1.4.5029`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).