### PR TITLE
feat(multi-scrobbler): 0.16.4 -> 0.16.5

### DIFF
--- a/pkgs/mu/multi-scrobbler/default.nix
+++ b/pkgs/mu/multi-scrobbler/default.nix
@@ -8,16 +8,16 @@
 
 buildNpmPackage rec {
   pname = "multi-scrobbler";
-  version = "0.16.4";
+  version = "0.16.5";
 
   src = fetchFromGitHub {
     owner = "FoxxMD";
     repo = "multi-scrobbler";
     rev = version;
-    hash = "sha256-Inzenh6wnv65ZrfdcSEfqXXhW96TabyNvla37zfxtJQ=";
+    hash = "sha256-EqJ265SGFlYGyxnKQciDPjATzznniKfEYbjYEDwjzMY=";
   };
 
-  npmDepsHash = "sha256-DrXxTQrpHEvOHEidNQZRa07uh+oYT/YionXbpvi6U8I=";
+  npmDepsHash = "sha256-XsmvmCzMdUoS95Tp006jAbYP0XALXL4k6UkFxafRBIo=";
 
   npmBuildScript = "build:frontend";
 


### PR DESCRIPTION
Update `multi-scrobbler` from `0.16.4` to `0.16.5`.

**Built on platform:**

- [x] `x86_64-linux`

Generated by [bumpkin](https://github.com/74k1/bumpkin).